### PR TITLE
Make cron scaler resilient to clock jumps, improve tests

### DIFF
--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -25,6 +25,7 @@ type cronScaler struct {
 	logger        logr.Logger
 	startSchedule cron.Schedule
 	endSchedule   cron.Schedule
+	clock         cronClock
 }
 
 type cronMetadata struct {
@@ -33,6 +34,24 @@ type cronMetadata struct {
 	Timezone        string `keda:"name=timezone,        order=triggerMetadata"`
 	DesiredReplicas int64  `keda:"name=desiredReplicas, order=triggerMetadata"`
 	TriggerIndex    int
+}
+
+type cronClock interface {
+	now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) now() time.Time {
+	return time.Now()
+}
+
+type mockClock struct {
+	fixedTime time.Time
+}
+
+func (m mockClock) now() time.Time {
+	return m.fixedTime
 }
 
 func (m *cronMetadata) Validate() error {
@@ -57,6 +76,10 @@ func (m *cronMetadata) Validate() error {
 }
 
 func NewCronScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
+	return newCronScalerWithClock(config, &realClock{})
+}
+
+func newCronScalerWithClock(config *scalersconfig.ScalerConfig, clock cronClock) (Scaler, error) {
 	metricType, err := GetMetricTargetType(config)
 	if err != nil {
 		return nil, fmt.Errorf("error getting scaler metric type: %w", err)
@@ -78,12 +101,8 @@ func NewCronScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 		logger:        InitializeLogger(config, "cron_scaler"),
 		startSchedule: startSchedule,
 		endSchedule:   endSchedule,
+		clock:         clock,
 	}, nil
-}
-
-func getCronTime(location *time.Location, schedule cron.Schedule) time.Time {
-	// Use the pre-parsed cron schedule directly to get the next time
-	return schedule.Next(time.Now().In(location))
 }
 
 func parseCronMetadata(config *scalersconfig.ScalerConfig) (cronMetadata, error) {
@@ -125,11 +144,12 @@ func (s *cronScaler) GetMetricsAndActivity(_ context.Context, metricName string)
 		return []external_metrics.ExternalMetricValue{}, false, fmt.Errorf("unable to load timezone: %w", err)
 	}
 
-	currentTime := time.Now().In(location)
+	// Only get the current time once, so non-monotonic clock behavior cannot cause unexpected behavior within this method
+	currentTime := s.clock.now().In(location)
 
 	// Use the pre-parsed schedules to get the next start and end times
-	nextStartTime := getCronTime(location, s.startSchedule)
-	nextEndTime := getCronTime(location, s.endSchedule)
+	nextStartTime := s.startSchedule.Next(currentTime)
+	nextEndTime := s.endSchedule.Next(currentTime)
 
 	isWithinInterval := false
 

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -39,6 +39,14 @@ var validCronMetadata2 = map[string]string{
 	"desiredReplicas": "10",
 }
 
+// A complete valid metadata example which is enabled every even hours
+var validCronMetadataCrossingMidnight = map[string]string{
+	"timezone":        "Etc/UTC",
+	"start":           "59 23 * * Thu",
+	"end":             "0 1 * * Thu",
+	"desiredReplicas": "10",
+}
+
 var testCronMetadata = []parseCronMetadataTestData{
 	{map[string]string{}, true},
 	{validCronMetadata, false},
@@ -59,8 +67,7 @@ var cronMetricIdentifiers = []cronMetricIdentifier{
 }
 
 var tz, _ = time.LoadLocation(validCronMetadata2["timezone"])
-var currentDay = time.Now().In(tz).Weekday().String()
-var currentHour = time.Now().In(tz).Hour()
+var clock = mockClock{fixedTime: time.Date(2025, 1, 23, 2, 2, 0, 0, tz)}
 
 func TestCronParseMetadata(t *testing.T) {
 	for _, testData := range testCronMetadata {
@@ -75,45 +82,35 @@ func TestCronParseMetadata(t *testing.T) {
 }
 
 func TestIsActive(t *testing.T) {
-	scaler, _ := NewCronScaler(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata})
-	_, isActive, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
-	if currentDay == "Thursday" {
-		assert.Equal(t, isActive, true)
-	} else {
-		assert.Equal(t, isActive, false)
-	}
+	scaler, _ := newCronScalerWithClock(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata}, clock)
+	_, isActive, _ := scaler.GetMetricsAndActivity(context.Background(), "ReplicaCount")
+	assert.True(t, isActive)
+}
+
+func TestIsActiveCrossingMidnight(t *testing.T) {
+	scaler, _ := newCronScalerWithClock(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadataCrossingMidnight}, clock)
+	_, isActive, _ := scaler.GetMetricsAndActivity(context.Background(), "ReplicaCount")
+	assert.False(t, isActive)
 }
 
 func TestIsActiveRange(t *testing.T) {
-	scaler, _ := NewCronScaler(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata2})
-	_, isActive, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
-	if currentHour%2 == 0 {
-		assert.Equal(t, isActive, true)
-	} else {
-		assert.Equal(t, isActive, false)
-	}
+	scaler, _ := newCronScalerWithClock(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata2}, clock)
+	_, isActive, _ := scaler.GetMetricsAndActivity(context.Background(), "ReplicaCount")
+	assert.True(t, isActive)
 }
 
 func TestGetMetrics(t *testing.T) {
-	scaler, _ := NewCronScaler(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata})
-	metrics, _, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	scaler, _ := newCronScalerWithClock(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata}, clock)
+	metrics, _, _ := scaler.GetMetricsAndActivity(context.Background(), "ReplicaCount")
 	assert.Equal(t, metrics[0].MetricName, "ReplicaCount")
-	if currentDay == "Thursday" {
-		assert.Equal(t, metrics[0].Value.Value(), int64(10))
-	} else {
-		assert.Equal(t, metrics[0].Value.Value(), int64(1))
-	}
+	assert.Equal(t, metrics[0].Value.Value(), int64(10))
 }
 
 func TestGetMetricsRange(t *testing.T) {
-	scaler, _ := NewCronScaler(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata2})
-	metrics, _, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	scaler, _ := newCronScalerWithClock(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMetadata2}, clock)
+	metrics, _, _ := scaler.GetMetricsAndActivity(context.Background(), "ReplicaCount")
 	assert.Equal(t, metrics[0].MetricName, "ReplicaCount")
-	if currentHour%2 == 0 {
-		assert.Equal(t, metrics[0].Value.Value(), int64(10))
-	} else {
-		assert.Equal(t, metrics[0].Value.Value(), int64(1))
-	}
+	assert.Equal(t, metrics[0].Value.Value(), int64(10))
 }
 
 func TestCronGetMetricSpecForScaling(t *testing.T) {


### PR DESCRIPTION
As I was reading the code for cron scaler considering whether it made sense for my organization to adopt it, I noticed that its internal logic isn't totally resilient to clock jumps from the non-monotonic clock.  

Having just experienced a very messy production outrage resulting from a clock jump forward then backward, I thought it would be a prudent and easy change to only get the time once, as unlikely as such a bug may be it may be.

I improved the unit tests a bit, by putting the `time.Now()` call behind an interface to eliminate any potential flakiness, and added a test case for when the start/end range crosses midnight.  

I didn't add tests for the hypothetical cases this change solves for because the structure obviates the need for them, but here's an example of a case that would have been problematic:
 - `start` is 00:09:00
 - `end` is 00:17:00
 - `currentTime` is 00:00:01 on Tuesday
 - When calculating `nextStartTime`, `time.Now()` is 00:00:01 on Tuesday so `nextStartTime` is 00:00:00 Wednesday
 - When calculating `nextEndTime`, `time.Now()` is (after jumping back) 23:59:59 on Monday so `nextEndTime` is 00:01:00 Tuesday
 - The conditional that calculates if the interval is within the same day is now confused: `nextStartTime.Before(nextEndTime)` is false, but the interval does _not_ span midnight
 - ...

It's worth noting that `time.Now()` [is quite clever](https://pkg.go.dev/time#hdr-Monotonic_Clocks) in that it provides a `time.Time` with a monotonic clock reading stored internally, so many comparison/math operations between times created with `time.Now()` are already resilient to clock jumps.  However, the `time.Time` returned by `cron.Schedule.Next()` is not guaranteed to have been created from the `time.Time` passed to it carrying that monotonic reading, so these time comparisons could still be flawed despite the cleverness.  Given this cleverness, I haven't reasoned through the _exact_ code path that would be problematic, but I've seen enough to know that this simple change seems worth it - it's arguably more clear anyway.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
